### PR TITLE
Automate vscode extension release process

### DIFF
--- a/.github/workflows/vscode-extension-release.yml
+++ b/.github/workflows/vscode-extension-release.yml
@@ -1,0 +1,89 @@
+name: VSCode Extension Release
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Changeset NPM Release"]
+    types:
+      - completed
+    branches:
+      - main
+
+permissions:
+  contents: write
+  packages: write
+  actions: read
+
+env:
+  FORCE_COLOR: 3
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+  NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+  NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
+  NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.NEXT_PUBLIC_POSTHOG_HOST }}
+  POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+  NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
+  NEXT_PUBLIC_APP_ENV: production
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    outputs:
+      is_version_bump: ${{ steps.check.outputs.is_version_bump }}
+      vscode_version_changed: ${{ steps.check-vscode.outputs.version_changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - id: check
+        run: |
+          if [[ "${{ github.event.workflow_run.head_commit.message }}" == *"chore: version packages"* ]]; then
+            echo "is_version_bump=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_version_bump=false" >> $GITHUB_OUTPUT
+          fi
+
+      - id: check-vscode
+        name: Check if VSCode extension version changed
+        run: |
+          # Check if the VSCode extension version was bumped in the last commit
+          if git diff HEAD~1 HEAD -- apps/vscode-extension/package.json | grep -q '"version"'; then
+            echo "version_changed=true" >> $GITHUB_OUTPUT
+            echo "VSCode extension version was changed"
+          else
+            echo "version_changed=false" >> $GITHUB_OUTPUT
+            echo "VSCode extension version was not changed"
+          fi
+
+  release:
+    name: Release VSCode Extension
+    needs: check-version
+    runs-on: ubuntu-latest
+    if: needs.check-version.outputs.is_version_bump == 'true' && needs.check-version.outputs.vscode_version_changed == 'true'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need full history for Changesets
+          fetch-depth: 0
+
+      - name: Setup Environment
+        uses: ./tooling/github/setup
+
+      - name: Get version from package.json
+        id: version
+        run: |
+          VERSION=$(node -p "require('./apps/vscode-extension/package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Release VSCode Extension
+        uses: ./tooling/github/vscode-extension/github-release
+        with:
+          version: ${{ steps.version.outputs.version }}
+          vsce_pat: ${{ env.VSCE_PAT }}

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -52,7 +52,7 @@
           },
           {
             "group": "Development",
-            "pages": ["contributing"]
+            "pages": ["contributing", "vscode-extension-automation"]
           }
         ]
       },

--- a/docs/vscode-extension-automation.mdx
+++ b/docs/vscode-extension-automation.mdx
@@ -1,0 +1,133 @@
+---
+title: "VSCode Extension Release Automation"
+description: "Automated release system for the VSCode extension"
+---
+
+# VSCode Extension Release Automation
+
+This document outlines the automated release system for the VSCode extension (`apps/vscode-extension`) that enables seamless publishing to the Visual Studio Marketplace.
+
+## Implementation Overview
+
+The automation consists of two main components:
+
+### 1. GitHub Workflow
+
+The workflow is defined in `.github/workflows/vscode-extension-release.yml`:
+
+**Triggers:**
+- Automatically after the "Changeset NPM Release" workflow completes
+- Manual dispatch for testing/emergency releases
+
+**Conditions:**
+- Only runs when the commit message contains "chore: version packages" (indicating a version bump)
+- Only runs when the VSCode extension's `package.json` version was actually changed
+
+**Process:**
+1. **Version Check**: Validates that this is a version bump commit and that the VSCode extension version specifically changed
+2. **Release**: Builds, packages, publishes to Visual Studio Marketplace, and creates GitHub release
+
+### 2. Composite Action
+
+The composite action is located at `tooling/github/vscode-extension/github-release/action.yml`:
+
+**Steps:**
+1. **Setup Environment**: Uses the shared setup action
+2. **Build Extension**: Runs `bun run build` to compile the extension
+3. **Package Extension**: Creates VSIX file using `bunx vsce package`
+4. **Publish to Marketplace**: Publishes to Visual Studio Marketplace using `bunx vsce publish`
+5. **Extract Changelog**: Reads version-specific changes from `CHANGELOG.md`
+6. **Create GitHub Release**: Creates release with tag `vscode-v{version}` and attaches VSIX file
+
+## Setup Requirements
+
+### Required GitHub Secrets
+
+Add the following secret to your GitHub repository:
+
+- `VSCE_PAT`: Personal Access Token for Visual Studio Marketplace
+  - Generate at: https://dev.azure.com/
+  - Requires "Marketplace (publish)" scope
+  - Should be associated with the publisher account ("unhook")
+
+### VSCode Extension Configuration
+
+The automation expects:
+- Extension built with Bun (already configured)
+- Extension publisher set to "unhook" in `package.json` (already set)
+- Changelog maintained in `apps/vscode-extension/CHANGELOG.md` with version sections like:
+
+```markdown
+## 0.0.3
+- Feature description
+- Bug fix description
+
+## 0.0.2
+- Previous version changes
+```
+
+## Workflow Integration
+
+### Automatic Process
+
+1. **Version Bump PR**: Changesets workflow creates PR with version bumps
+2. **PR Merge**: When PR is merged to `main`, Changeset NPM Release workflow runs
+3. **VSCode Release**: If VSCode extension version changed, the VSCode Extension Release workflow automatically triggers
+4. **Marketplace Publication**: Extension is built, packaged, and published
+5. **GitHub Release**: Release created with VSIX file attachment
+
+### Manual Fallback
+
+If automation fails, manual release steps:
+
+```bash
+# Navigate to extension directory
+cd apps/vscode-extension
+
+# Build extension
+bun run build
+
+# Package extension
+bunx vsce package
+
+# Publish to marketplace
+bunx vsce publish
+```
+
+## Monitoring
+
+The workflow provides clear logging for each step:
+- Build status and output
+- Package creation
+- Marketplace publishing result
+- GitHub release creation
+
+Failed steps will be clearly indicated in the GitHub Actions logs.
+
+## Security Considerations
+
+- `VSCE_PAT` is securely stored as a GitHub secret
+- Token has minimal required permissions (marketplace publish only)
+- Extension files are built from source during workflow execution
+- All steps logged for audit trail
+
+## File Structure
+
+```
+.github/workflows/
+└── vscode-extension-release.yml
+
+tooling/github/vscode-extension/
+└── github-release/
+    └── action.yml
+```
+
+<Note>
+The workflow only triggers when the VSCode extension version specifically changes. GitHub releases use the tag format `vscode-v{version}` to distinguish from CLI releases.
+</Note>
+
+## Best Practices
+
+- VSIX files are automatically attached to GitHub releases for manual distribution
+- The automation follows the same patterns as the existing CLI release workflow for consistency
+- Version management is handled by the Changesets workflow - no manual version bumping required

--- a/tooling/github/vscode-extension/github-release/action.yml
+++ b/tooling/github/vscode-extension/github-release/action.yml
@@ -1,0 +1,88 @@
+name: "Release VSCode Extension"
+description: "Package and publish VSCode extension to Visual Studio Marketplace and create GitHub release"
+
+inputs:
+  version:
+    description: "Version number for the release"
+    required: true
+  vsce_pat:
+    description: "Personal Access Token for Visual Studio Marketplace"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Environment
+      uses: ./tooling/github/setup
+
+    - name: Build VSCode Extension
+      shell: bash
+      working-directory: apps/vscode-extension
+      run: |
+        echo "Building VSCode extension..."
+        bun run build
+
+    - name: Package VSCode Extension
+      shell: bash
+      working-directory: apps/vscode-extension
+      run: |
+        echo "Packaging VSCode extension..."
+        bunx vsce package --out unhook-vscode-${{ inputs.version }}.vsix
+
+    - name: Publish to Visual Studio Marketplace
+      shell: bash
+      working-directory: apps/vscode-extension
+      env:
+        VSCE_PAT: ${{ inputs.vsce_pat }}
+      run: |
+        echo "Publishing to Visual Studio Marketplace..."
+        bunx vsce publish --packagePath unhook-vscode-${{ inputs.version }}.vsix
+
+    - name: Read changelog
+      id: changelog
+      shell: bash
+      working-directory: apps/vscode-extension
+      run: |
+        # Read the changelog file
+        CHANGELOG=$(cat CHANGELOG.md)
+        VERSION="${{ inputs.version }}"
+
+        # Find the start of the version section
+        START_LINE=$(echo "$CHANGELOG" | grep -n "^## $VERSION" | cut -d: -f1)
+        if [ -z "$START_LINE" ]; then
+          echo "Could not find version $VERSION in changelog"
+          exit 1
+        fi
+
+        # Find the next version section or end of file
+        NEXT_VERSION_LINE=$(echo "$CHANGELOG" | tail -n +$((START_LINE + 1)) | grep -n "^## " | head -n 1 | cut -d: -f1)
+
+        if [ -z "$NEXT_VERSION_LINE" ]; then
+          # If no next version found, take everything until the end
+          BODY=$(echo "$CHANGELOG" | tail -n +$((START_LINE + 1)))
+        else
+          # Take content until the next version
+          BODY=$(echo "$CHANGELOG" | tail -n +$((START_LINE + 1)) | head -n $((NEXT_VERSION_LINE - 1)))
+        fi
+
+        # Clean up the content
+        BODY=$(echo "$BODY" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+
+        # Set output
+        echo "body<<EOF" >> $GITHUB_OUTPUT
+        echo "$BODY" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
+
+    - name: Create GitHub Release
+      id: create_release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: vscode-v${{ inputs.version }}
+        name: VSCode Extension v${{ inputs.version }}
+        body: ${{ steps.changelog.outputs.body }}
+        draft: false
+        prerelease: false
+        files: |
+          apps/vscode-extension/unhook-vscode-${{ inputs.version }}.vsix
+      env:
+        GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}


### PR DESCRIPTION
An automated release system for the VSCode extension was implemented, mirroring existing CLI release patterns.

*   A new GitHub workflow, `.github/workflows/vscode-extension-release.yml`, was created. It triggers upon completion of the "Changeset NPM Release" workflow, specifically when a "chore: version packages" commit is detected and the `apps/vscode-extension/package.json` version has changed.
*   This workflow utilizes a new composite action, `tooling/github/vscode-extension/github-release/action.yml`. This action encapsulates the build (`bun run build`), packaging (`bunx vsce package`), and publishing (`bunx vsce publish`) steps to the Visual Studio Marketplace.
*   The composite action also extracts relevant changelog entries from `apps/vscode-extension/CHANGELOG.md` to generate GitHub release notes and attaches the generated VSIX file to a new GitHub release tagged `vscode-v{version}`.
*   Documentation for this automation, initially in `vscode-extension-release-automation.md`, was moved to `docs/vscode-extension-automation.mdx`, converted to MDX format, and integrated into the Mintlify navigation via `docs/docs.json` for improved accessibility.