### PR TITLE
Fix config loader

### DIFF
--- a/apps/cli/src/stores/config-store.ts
+++ b/apps/cli/src/stores/config-store.ts
@@ -47,7 +47,7 @@ const store = createStore<ConfigStore>()((set, get) => ({
       const config = await loadConfig(configPath);
       log('Loaded config:', config);
       set(config);
-      return defaultConfigState;
+      return config;
     } catch (error) {
       log('Error loading config:', error);
       return defaultConfigState;


### PR DESCRIPTION
## Summary
- return the loaded config from `loadConfig`

## Testing
- `bun test` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6859c08384808333998d86e765421b26