### PR TITLE
Fix connectedAt typo in DB schema

### DIFF
--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -683,7 +683,7 @@ export const UpdateConnectionTypeSchema = createUpdateSchema(Connections, {
   clientVersion: z.string().optional(),
   clientOs: z.string().optional(),
   clientHostname: z.string().optional(),
-  cobnnectedAt: z.date(),
+  connectedAt: z.date(),
   disconnectedAt: z.date().optional(),
   lastPingAt: z.date(),
   userId: z.string(),


### PR DESCRIPTION
## Summary
- fix property name in `UpdateConnectionTypeSchema`

## Testing
- `bun run lint:ws` *(fails: bunx command not found)*
- `bun run format:ci` *(fails: biome not found)*
- `bun test` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6859c1f769ac8333b357a50f583e13ae