### PR TITLE
Remove redundant configuration change listener

### DIFF
--- a/apps/vscode-extension/src/commands/delivery.commands.ts
+++ b/apps/vscode-extension/src/commands/delivery.commands.ts
@@ -36,22 +36,7 @@ export function registerDeliveryCommands(context: vscode.ExtensionContext) {
     },
   );
 
-  // Listen for configuration changes to update settings service
-  const configChangeListener = vscode.workspace.onDidChangeConfiguration(
-    (e) => {
-      if (e.affectsConfiguration('unhook.delivery.enabled')) {
-        const config = vscode.workspace.getConfiguration('unhook');
-        const newSettings = {
-          delivery: {
-            enabled: config.get<boolean>('delivery.enabled', true),
-          },
-        };
-        settingsService.updateSettings(newSettings);
-      }
-    },
-  );
-
-  context.subscriptions.push(toggleDeliveryCommand, configChangeListener);
+  context.subscriptions.push(toggleDeliveryCommand);
 }
 
 export function isDeliveryPaused(): boolean {


### PR DESCRIPTION
Remove redundant `unhook.delivery.enabled` configuration listener.

The `SettingsService` already has a comprehensive listener for all `unhook` configuration changes. This duplicate listener in `delivery.commands.ts` caused `settingsService.updateSettings()` to be called and `settingsChanged` events to be emitted twice, leading to potential race conditions and inefficient processing.