### PR TITLE
Fix documentation links to correct locations

### DIFF
--- a/docs/providers.mdx
+++ b/docs/providers.mdx
@@ -13,42 +13,42 @@ Unhook makes it easy to receive webhooks from any provider. Each provider has sp
   <Card
     title="Stripe"
     icon="stripe"
-    href="/docs/providers/stripe"
+    href="/providers/stripe"
   >
     Payment processing and subscription webhooks
   </Card>
   <Card
     title="GitHub"
     icon="github"
-    href="/docs/providers/github"
+    href="/providers/github"
   >
     Repository and workflow events
   </Card>
   <Card
     title="Clerk"
     icon="user-shield"
-    href="/docs/providers/clerk"
+    href="/providers/clerk"
   >
     User authentication and management
   </Card>
   <Card
     title="Twilio"
     icon="comment-sms"
-    href="/docs/providers/twilio"
+    href="/providers/twilio"
   >
     SMS, voice, and communication events
   </Card>
   <Card
     title="SendGrid"
     icon="envelope"
-    href="/docs/providers/sendgrid"
+    href="/providers/sendgrid"
   >
     Email delivery and engagement tracking
   </Card>
   <Card
     title="Shopify"
     icon="cart-shopping"
-    href="/docs/providers/shopify"
+    href="/providers/shopify"
   >
     E-commerce and order webhooks
   </Card>
@@ -57,105 +57,105 @@ Unhook makes it easy to receive webhooks from any provider. Each provider has sp
 ## Payment & Commerce
 
 <CardGroup cols={3}>
-  <Card title="PayPal" href="/docs/providers/paypal">Payment notifications</Card>
-  <Card title="Square" href="/docs/providers/square">Payment and POS events</Card>
-  <Card title="Braintree" href="/docs/providers/braintree">Payment gateway webhooks</Card>
-  <Card title="Paddle" href="/docs/providers/paddle">SaaS billing events</Card>
-  <Card title="Chargebee" href="/docs/providers/chargebee">Subscription management</Card>
-  <Card title="Recurly" href="/docs/providers/recurly">Recurring billing webhooks</Card>
+  <Card title="PayPal" href="/providers/paypal">Payment notifications</Card>
+  <Card title="Square" href="/providers/square">Payment and POS events</Card>
+  <Card title="Braintree" href="/providers/braintree">Payment gateway webhooks</Card>
+  <Card title="Paddle" href="/providers/paddle">SaaS billing events</Card>
+  <Card title="Chargebee" href="/providers/chargebee">Subscription management</Card>
+  <Card title="Recurly" href="/providers/recurly">Recurring billing webhooks</Card>
 </CardGroup>
 
 ## Communication & Collaboration
 
 <CardGroup cols={3}>
-  <Card title="Slack" href="/docs/providers/slack">Team messaging events</Card>
-  <Card title="Discord" href="/docs/providers/discord">Community platform webhooks</Card>
-  <Card title="Microsoft Teams" href="/docs/providers/microsoft-teams">Enterprise communication</Card>
-  <Card title="Zoom" href="/docs/providers/zoom">Video conferencing events</Card>
-  <Card title="Intercom" href="/docs/providers/intercom">Customer messaging</Card>
-  <Card title="Mailchimp" href="/docs/providers/mailchimp">Email marketing events</Card>
+  <Card title="Slack" href="/providers/slack">Team messaging events</Card>
+  <Card title="Discord" href="/providers/discord">Community platform webhooks</Card>
+  <Card title="Microsoft Teams" href="/providers/microsoft-teams">Enterprise communication</Card>
+  <Card title="Zoom" href="/providers/zoom">Video conferencing events</Card>
+  <Card title="Intercom" href="/providers/intercom">Customer messaging</Card>
+  <Card title="Mailchimp" href="/providers/mailchimp">Email marketing events</Card>
 </CardGroup>
 
 ## Development & Infrastructure
 
 <CardGroup cols={3}>
-  <Card title="Vercel" href="/docs/providers/vercel">Deployment notifications</Card>
-  <Card title="Netlify" href="/docs/providers/netlify">Build and deploy events</Card>
-  <Card title="CircleCI" href="/docs/providers/circleci">CI/CD pipeline webhooks</Card>
-  <Card title="PagerDuty" href="/docs/providers/pagerduty">Incident management</Card>
-  <Card title="Sentry" href="/docs/providers/sentry">Error tracking alerts</Card>
-  <Card title="Datadog" href="/docs/providers/datadog">Monitoring and analytics</Card>
+  <Card title="Vercel" href="/providers/vercel">Deployment notifications</Card>
+  <Card title="Netlify" href="/providers/netlify">Build and deploy events</Card>
+  <Card title="CircleCI" href="/providers/circleci">CI/CD pipeline webhooks</Card>
+  <Card title="PagerDuty" href="/providers/pagerduty">Incident management</Card>
+  <Card title="Sentry" href="/providers/sentry">Error tracking alerts</Card>
+  <Card title="Datadog" href="/providers/datadog">Monitoring and analytics</Card>
 </CardGroup>
 
 ## Project Management
 
 <CardGroup cols={3}>
-  <Card title="Linear" href="/docs/providers/linear">Issue tracking</Card>
-  <Card title="Jira" href="/docs/providers/jira">Agile project management</Card>
-  <Card title="Notion" href="/docs/providers/notion">Workspace notifications</Card>
-  <Card title="Asana" href="/docs/providers/asana">Task management</Card>
-  <Card title="Monday.com" href="/docs/providers/monday">Work OS events</Card>
-  <Card title="ClickUp" href="/docs/providers/clickup">Productivity platform</Card>
+  <Card title="Linear" href="/providers/linear">Issue tracking</Card>
+  <Card title="Jira" href="/providers/jira">Agile project management</Card>
+  <Card title="Notion" href="/providers/notion">Workspace notifications</Card>
+  <Card title="Asana" href="/providers/asana">Task management</Card>
+  <Card title="Monday.com" href="/providers/monday">Work OS events</Card>
+  <Card title="ClickUp" href="/providers/clickup">Productivity platform</Card>
 </CardGroup>
 
 ## Authentication & Security
 
 <CardGroup cols={3}>
-  <Card title="Auth0" href="/docs/providers/auth0">Identity management</Card>
-  <Card title="Okta" href="/docs/providers/okta">Enterprise authentication</Card>
-  <Card title="Firebase" href="/docs/providers/firebase">Authentication events</Card>
-  <Card title="Supabase" href="/docs/providers/supabase">Backend platform webhooks</Card>
-  <Card title="WorkOS" href="/docs/providers/workos">Enterprise SSO</Card>
-  <Card title="FusionAuth" href="/docs/providers/fusionauth">Customer identity</Card>
+  <Card title="Auth0" href="/providers/auth0">Identity management</Card>
+  <Card title="Okta" href="/providers/okta">Enterprise authentication</Card>
+  <Card title="Firebase" href="/providers/firebase">Authentication events</Card>
+  <Card title="Supabase" href="/providers/supabase">Backend platform webhooks</Card>
+  <Card title="WorkOS" href="/providers/workos">Enterprise SSO</Card>
+  <Card title="FusionAuth" href="/providers/fusionauth">Customer identity</Card>
 </CardGroup>
 
 ## Form & Survey
 
 <CardGroup cols={3}>
-  <Card title="Typeform" href="/docs/providers/typeform">Form submissions</Card>
-  <Card title="Google Forms" href="/docs/providers/google-forms">Survey responses</Card>
-  <Card title="JotForm" href="/docs/providers/jotform">Form builder webhooks</Card>
-  <Card title="SurveyMonkey" href="/docs/providers/surveymonkey">Survey platform</Card>
-  <Card title="Calendly" href="/docs/providers/calendly">Scheduling events</Card>
-  <Card title="Cal.com" href="/docs/providers/cal">Open-source scheduling</Card>
+  <Card title="Typeform" href="/providers/typeform">Form submissions</Card>
+  <Card title="Google Forms" href="/providers/google-forms">Survey responses</Card>
+  <Card title="JotForm" href="/providers/jotform">Form builder webhooks</Card>
+  <Card title="SurveyMonkey" href="/providers/surveymonkey">Survey platform</Card>
+  <Card title="Calendly" href="/providers/calendly">Scheduling events</Card>
+  <Card title="Cal.com" href="/providers/cal">Open-source scheduling</Card>
 </CardGroup>
 
 ## Storage & Files
 
 <CardGroup cols={3}>
-  <Card title="Box" href="/docs/providers/box">File collaboration</Card>
-  <Card title="Dropbox" href="/docs/providers/dropbox">Cloud storage events</Card>
-  <Card title="Google Drive" href="/docs/providers/google-drive">Document notifications</Card>
-  <Card title="OneDrive" href="/docs/providers/onedrive">Microsoft cloud storage</Card>
-  <Card title="AWS S3" href="/docs/providers/aws-s3">Object storage events</Card>
-  <Card title="Cloudinary" href="/docs/providers/cloudinary">Media management</Card>
+  <Card title="Box" href="/providers/box">File collaboration</Card>
+  <Card title="Dropbox" href="/providers/dropbox">Cloud storage events</Card>
+  <Card title="Google Drive" href="/providers/google-drive">Document notifications</Card>
+  <Card title="OneDrive" href="/providers/onedrive">Microsoft cloud storage</Card>
+  <Card title="AWS S3" href="/providers/aws-s3">Object storage events</Card>
+  <Card title="Cloudinary" href="/providers/cloudinary">Media management</Card>
 </CardGroup>
 
 ## Analytics & Marketing
 
 <CardGroup cols={3}>
-  <Card title="Segment" href="/docs/providers/segment">Customer data events</Card>
-  <Card title="Mixpanel" href="/docs/providers/mixpanel">Product analytics</Card>
-  <Card title="Amplitude" href="/docs/providers/amplitude">Digital analytics</Card>
-  <Card title="HubSpot" href="/docs/providers/hubspot">CRM and marketing</Card>
-  <Card title="Salesforce" href="/docs/providers/salesforce">Enterprise CRM</Card>
-  <Card title="Pipedrive" href="/docs/providers/pipedrive">Sales CRM webhooks</Card>
+  <Card title="Segment" href="/providers/segment">Customer data events</Card>
+  <Card title="Mixpanel" href="/providers/mixpanel">Product analytics</Card>
+  <Card title="Amplitude" href="/providers/amplitude">Digital analytics</Card>
+  <Card title="HubSpot" href="/providers/hubspot">CRM and marketing</Card>
+  <Card title="Salesforce" href="/providers/salesforce">Enterprise CRM</Card>
+  <Card title="Pipedrive" href="/providers/pipedrive">Sales CRM webhooks</Card>
 </CardGroup>
 
 ## Social Media
 
 <CardGroup cols={3}>
-  <Card title="Facebook" href="/docs/providers/facebook">Social platform events</Card>
-  <Card title="Instagram" href="/docs/providers/instagram">Photo sharing webhooks</Card>
-  <Card title="Twitter/X" href="/docs/providers/twitter">Social media events</Card>
-  <Card title="LinkedIn" href="/docs/providers/linkedin">Professional network</Card>
-  <Card title="TikTok" href="/docs/providers/tiktok">Video platform webhooks</Card>
-  <Card title="YouTube" href="/docs/providers/youtube">Video notifications</Card>
+  <Card title="Facebook" href="/providers/facebook">Social platform events</Card>
+  <Card title="Instagram" href="/providers/instagram">Photo sharing webhooks</Card>
+  <Card title="Twitter/X" href="/providers/twitter">Social media events</Card>
+  <Card title="LinkedIn" href="/providers/linkedin">Professional network</Card>
+  <Card title="TikTok" href="/providers/tiktok">Video platform webhooks</Card>
+  <Card title="YouTube" href="/providers/youtube">Video notifications</Card>
 </CardGroup>
 
 ## Custom Providers
 
-If your provider is not listed above, you can still use Unhook! Simply use your unique Unhook URL as the webhook endpoint. See our [Custom Integration Guide](/docs/providers/custom) for more details.
+If your provider is not listed above, you can still use Unhook! Simply use your unique Unhook URL as the webhook endpoint. See our [Custom Integration Guide](/providers/custom) for more details.
 
 ## Quick Start
 


### PR DESCRIPTION
Update provider links in `docs/providers.mdx` to correct navigation by removing the `/docs/` prefix.