### PR TITLE
Adjust vscode activity bar icon size

### DIFF
--- a/apps/vscode-extension/activitybar-icon.svg
+++ b/apps/vscode-extension/activitybar-icon.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 4C15.3137 4 18 6.68629 18 10V14C18 17.3137 15.3137 20 12 20C8.68629 20 6 17.3137 6 14C6 10.6863 8.68629 8 12 8C13.1046 8 14 8.89543 14 10V14C14 15.1046 13.1046 16 12 16C10.8954 16 10 15.1046 10 14V10" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none"/>
+  <circle cx="12" cy="4" r="2" fill="currentColor"/>
+</svg>

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -226,7 +226,7 @@
     "viewsContainers": {
       "activitybar": [
         {
-          "icon": "logo.svg",
+          "icon": "activitybar-icon.svg",
           "id": "unhook",
           "title": "Unhook"
         }


### PR DESCRIPTION
Replace oversized activity bar icon with a properly sized and monochrome SVG.

The previous `logo.svg` (1024x1024) was being drastically scaled down by VSCode, causing the activity bar icon to appear much smaller than others. This PR introduces `activitybar-icon.svg` (24x24, monochrome, optimized for small sizes) and updates `package.json` to use it, ensuring correct display and adherence to VSCode icon guidelines.