### PR TITLE
Update middleware for competitor pages

### DIFF
--- a/apps/web-app/src/middleware.ts
+++ b/apps/web-app/src/middleware.ts
@@ -11,6 +11,10 @@ const isPublicRoute = createRouteMatcher([
   '/',
   '/privacy-policy',
   '/terms-of-service',
+  // Marketing pages
+  '/pricing(.*)',
+  '/vscode(.*)',
+  '/webhook-graphic-demo(.*)',
   // VS competitor pages
   '/vs-svix(.*)',
   '/vs-webhook-site(.*)',


### PR DESCRIPTION
Allow unauthenticated access to 'vs competitors' and marketing pages by adding them to public routes.