### PR TITLE
Fix vscode extension sign-in error

### DIFF
--- a/apps/vscode-extension/src/register-auth-uri-handler.ts
+++ b/apps/vscode-extension/src/register-auth-uri-handler.ts
@@ -21,7 +21,11 @@ export function registerUriHandler(
       log('Handling URI:', uri.toString());
       // Handle any of our supported editor schemes
       if (uri.authority === env.NEXT_PUBLIC_VSCODE_EXTENSION_ID) {
-        const code = uri.query.split('=')[1];
+        // Decode the query string first to handle URL-encoded parameters
+        const decodedQuery = decodeURIComponent(uri.query);
+        const params = new URLSearchParams(decodedQuery);
+        const code = params.get('code');
+
         if (code && authProvider) {
           try {
             // Complete the auth flow in the provider


### PR DESCRIPTION
Fix VSCode extension sign-in by correctly parsing URL-encoded authentication URIs.

The previous implementation failed to sign in because the URI query parameter was URL-encoded (e.g., `code%3D...`), but the code attempted to split on `=` directly without decoding, resulting in an invalid authorization code. This change decodes the URI and uses `URLSearchParams` for robust parsing.